### PR TITLE
Implement attribute and category selection on product filter

### DIFF
--- a/src/services/guardService.ts
+++ b/src/services/guardService.ts
@@ -119,6 +119,14 @@ export const guardService = createApi({
             }),
             providesTags: ['guard'],
         }),
+        // Liste des types d'attributs (ex: taille, pointure, mèches, etc.)
+        getAttributes: builder.query({
+            query: () => ({
+                url: `/api/attributes`,
+                method: 'GET'
+            }),
+            providesTags: ['guard'],
+        }),
         getProductByUrl: builder.query({
             query: (url) => ({
                 url: `/api/product/detail/${url}`,
@@ -220,6 +228,7 @@ export const {
     useGetAllShopsQuery,
     useGetCurrentHomeByGenderQuery,
     useGetHomeProductsQuery,
+    useGetAttributesQuery,
     useGetProductByUrlQuery,
     useGetAllProductsQuery,
     useCreateDeliveryMutation,


### PR DESCRIPTION
Refactor product filters on `ProductListPage` to use select dropdowns for categories and introduce a two-step selection for product attributes (type then value), excluding color.

The previous category filter allowed multiple selections via checkboxes, which was not the desired behavior. This PR updates it to a single-select dropdown. Additionally, a new filtering mechanism for product attributes (e.g., size, shoe size) has been implemented, allowing users to first choose an attribute type and then a specific value, while explicitly excluding 'Couleur' (color) from this new attribute filter section as per the user's request.

---
<a href="https://cursor.com/background-agent?bcId=bc-d838201a-9da7-44f4-a454-8091086c3259">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d838201a-9da7-44f4-a454-8091086c3259">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

